### PR TITLE
エラーハンドリング修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,6 +38,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
+      @item.images.new
       render :new
     end
   end

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,13 +1,13 @@
 {
-  "application.js": "/packs/js/application-e4461dd6b52338e99447.js",
-  "application.js.map": "/packs/js/application-e4461dd6b52338e99447.js.map",
+  "application.js": "/packs/js/application-89fbe6d8d4f49b484fb9.js",
+  "application.js.map": "/packs/js/application-89fbe6d8d4f49b484fb9.js.map",
   "entrypoints": {
     "application": {
       "js": [
-        "/packs/js/application-e4461dd6b52338e99447.js"
+        "/packs/js/application-89fbe6d8d4f49b484fb9.js"
       ],
       "js.map": [
-        "/packs/js/application-e4461dd6b52338e99447.js.map"
+        "/packs/js/application-89fbe6d8d4f49b484fb9.js.map"
       ]
     }
   }


### PR DESCRIPTION
#what 
renderの遷移先で画像選択ファイルを表示させる。

#why
選択ファイルがなく画像の選択が不可となるため。